### PR TITLE
Use peer dep bedrock-security-context@5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 - **BREAKING**: Set engines.node >=12.0.0.
-- **BREAKING**: Use bedrock-security-context@4.
+- **BREAKING**: Use bedrock-security-context@5.
 
 ### Added
 - Setup test.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "peerDependencies": {
     "bedrock": "^4.0.0",
     "bedrock-jsonld-document-loader": "^1.0.0",
-    "bedrock-security-context": "^4.1.0"
+    "bedrock-security-context": "^5.0.0"
   },
   "engines": {
     "node": ">=12.0.0"


### PR DESCRIPTION
Previous round of peer dep updates was never released.